### PR TITLE
ChatGPT for translation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Curated by [Reorx](https://reorx.com), you are welcome to suggest new projects v
     Make bilingual epub books Using AI translate. Original tweet [@yihong0618](https://twitter.com/yihong0618/status/1630948132564631552)
 
     There's a web UI at [streamlit](https://goldengrape-bilingual-book-maker-streamlit-app-x7nhof.streamlit.app/), made by the author of this [tweet](https://twitter.com/goldengrape/status/1631549869306572800).
+    
+- [ChatGPT-for-Translation](https://github.com/Raychanan/ChatGPT-for-Translation)
+    
+    Python tool for translating text files. It provides bilingual translation, multithreading, and automatic handling of excessive request frequency.
 
 - [AI Commits](https://github.com/Nutlope/aicommits)
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -79,6 +79,10 @@
     用于制作双语 epub 电子书的 Python 脚本。原推: [@yihong0618](https://twitter.com/yihong0618/status/1630948132564631552)
 
     Web UI [streamlit](https://goldengrape-bilingual-book-maker-streamlit-app-x7nhof.streamlit.app/)。原推: [tweet](https://twitter.com/goldengrape/status/1631549869306572800).
+    
+- [ChatGPT-for-Translation](https://github.com/Raychanan/ChatGPT-for-Translation)
+    
+    对文本文件进行翻译的 Python 脚本。同时提供双语翻译、多线程和自动处理过高的请求频率。
 
 - [AI Commits](https://github.com/Nutlope/aicommits)
 


### PR DESCRIPTION
This is a simple python tool supporting direct, bi-lingual, multithreading, and auto handling of excessive request frequency to abide by OpenAI‘s limit.

这是一个简单的Python工具，支持直接、双语、多线程，并自动处理过度请求频率以遵守OpenAI的限制。