### PR TITLE
feat: add ChatGPT for ChatBot Feishu

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Curated by [Reorx](https://reorx.com), you are welcome to suggest new projects v
     - [bestony/ChatGPT-Feishu](https://github.com/bestony/ChatGPT-Feishu)
     - [Leizhenpeng feishu-chatGpt](https://github.com/Leizhenpeng/feishu-chatGpt)
     - [key7men/openai-feishu-bot](https://github.com/key7men/openai-feishu-bot)
+    - [go-zoox/chatgpt-for-chatbot-feishu](https://github.com/go-zoox/chatgpt-for-chatbot-feishu)
 - Teams
     - [formulahendry/chatgpt-teams-bot](https://github.com/formulahendry/chatgpt-teams-bot)
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -151,6 +151,7 @@
     - [bestony/ChatGPT-Feishu](https://github.com/bestony/ChatGPT-Feishu)
     - [Leizhenpeng feishu-chatGpt](https://github.com/Leizhenpeng/feishu-chatGpt)
     - [key7men/openai-feishu-bot](https://github.com/key7men/openai-feishu-bot)
+    - [go-zoox/chatgpt-for-chatbot-feishu](https://github.com/go-zoox/chatgpt-for-chatbot-feishu)
 - Teams
     - [formulahendry/chatgpt-teams-bot](https://github.com/formulahendry/chatgpt-teams-bot)
 


### PR DESCRIPTION
###
* zh_cn: ChatGPT for ChatBot Feishu 是一个快速将 ChatGPT 接入飞书的应用，基于 OpenAI 官方接口 GPT3 模型，支持私有部署，作为私人工作助理或者企业员工助理。
* en_us: ChatGPT for ChatBot Feishu is an app for quickly integrating ChatGPT with Feishu, based on the official OpenAI interface GPT-3 model and supporting private deployment, which can be used as a personal assistant for work or an enterprise employee assistant. (Translated by it)

### Git Repo
* https://github.com/go-zoox/chatgpt-for-chatbot-feishu

### License
* MIT

### See more
* README: https://github.com/go-zoox/chatgpt-for-chatbot-feishu
* Recommand: https://github.com/ruanyf/weekly/issues/2927