### PR TITLE
docs: add `chatgpt-cli` to CLI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ Curated by [Reorx](https://reorx.com), you are welcome to suggest new projects v
 
     Python tool for translating text files. It provides bilingual translation, multithreading, and automatic handling of excessive request frequency.
 
+- [chatgpt-cli](https://github.com/efJerryYang/chatgpt-cli/)
+
+    A markdown-supported command-line interface tool that connects to ChatGPT using OpenAI's API key. Commands provided enable you to use this tool much like you would use the official web client. Conversations are saved as JSON format in your machine.
 
 ## Chatbots
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -163,6 +163,9 @@
 
     对文本文件进行翻译的 Python 脚本。同时提供双语翻译、多线程和自动处理过高的请求频率。
 
+- [chatgpt-cli](https://github.com/efJerryYang/chatgpt-cli/)
+
+    支持 Markdown 的 ChatGPT CLI 工具，使用 OpenAI 官方 API。提供多个命令实现官方 web 客户端近似的功能以方便使用，会话以 JSON 格式保存到本地。
 
 ## 聊天机器人
 


### PR DESCRIPTION
Requirements:
1. Use the official API key from OpenAI.
2. The key can be configured by an interactive procedure when running for the first time, or configure the `config.yaml` file manually. A template is provided in the repository.
3. Markdown support is similar to many, but I provide a list of the most frequently used commands to make the experience much like the original web client. Conversations can be saved and loaded with commands. Additionally, Exiting with an unsaved conversation with be prompted to save or ignore. Supported commands are as follows:

    - `!help`: shows the help message
    - `!show`: displays the current conversation messages
    - `!save`: saves the current conversation to a `JSON` file
    - `!load`: loads a conversation from a `JSON` file
    - `!new` or `!reset`: starts a new conversation
    - `!regen`: regenerates the last response
    - `!resend`: resends your last prompt to generate response
    - `!edit`: selects messages for editing
    - `!drop`: selects messages for deletion
    - `!exit` or `!quit`: exits the program

要求：
1. 使用了 OpenAI 官方 ChatGPT API
2. 可以在首次运行的时候根据交互式提示设置 API key，或者用户可以手动编辑 `config.yaml` 文件进行设置。仓库中提供了模板。
3. 支持 Markdown 这一特性和很多的是相同的，但本人提供了一些非常常用的命令，让控制台的交互和官方网页端相似。除此以外，对话可以通过命令保存到本地，也可以从本地加载。退出时如果当前会话未保存会提示，由用户选择保存或者跳过。支持的命令包括：

    - `!help` 呈现帮助信息，目前只有英文显示
    - `!show` 用来呈现当前会话的所有消息（以 Markdown 渲染的格式）
    - `!save` 保存当前会话到 `JSON` 文件
    - `!load` 从文件加载会话，如果遇到当前会话未保存的情况，会提醒你是否选择保存当前会话。
    - `!regen` 重新生成最后一次 ChatGPT 的回复
    - `!new` 或者 `!reset` 重置会话，如果未保存的话会提示是否保存
    - `!drop` 目前用于删除掉某一段消息，可以是 ChatGPT 的也可以是你发的
    - `!resend` 通常用于在发送失败的情况下，如遇到网络错误，重新发送上一次的消息
    - `!edit` 用于编辑会话，双方的话都可以编辑
    - `!exit` 或者 `!quit` 退出，未保存的情况下也会提示是否保存