### PR TITLE
Added aider CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,12 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
     DoctorGPT brings GPT into production for application log error diagnosing.
 
+- [aider](https://github.com/paul-gauthier/aider)
+
+    aider is a command-line chat tool that allows you to code with GPT-4 in the terminal. Ask GPT for features, improvements, or bug fixes and aider will apply the suggested changes to your source files. Each change is automatically committed to git with a descriptive commit message.
+
+
+
 ## Chatbots
 
 - Telegram


### PR DESCRIPTION
I would like to propose adding `aider` to the Awesome ChatGPT API list.

`aider` is a command-line chat tool that allows developers to code with GPT-4 in the terminal. Users can ask GPT for features, improvements, or bug fixes, and `aider` will apply the suggested changes to their source files. Each change is automatically committed to git with a descriptive commit message.

You can find more information about `aider` in its GitHub repository: https://github.com/paul-gauthier/aider

I believe that `aider` would be a valuable addition to the list, as it showcases a practical application of GPT-4 in a developer's workflow.

Please let me know if you need any additional information or if there are any changes required for the inclusion of `aider` in the list.

Thank you for considering this request.

Best,
Paul
