### PR TITLE
Add Composum AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
         A LaunchBar action to interact with the ChatGPT API. Responses are received directly in LaunchBar and can be browsed, opened, previewed with Quick Look, inserted, or sent to another action. Conversation history is preserved for context. ChatGPT system messages are configurable via personas.
 
+- CMS extensions
+
+    - [Composum AI](https://github.com/ist-dresden/composum-AI)
+ 
+      OpenAI based GenAI extension for the CMS Adobe Experience Manager (AEM) or the free Composum Pages CMS to analyze, discuss, suggest, translate, transform texts, incl. free prompting.
 
 ## Web Apps
 


### PR DESCRIPTION
Hi!

The Composum AI provides extensions for both the Adobe Experience Manager (AEM) or the free Composum Pages CMS that tightly integrates OpenAI ChatGPT capabilities into the CMS editor to allow content authors to analyze and discuss 
content with ChatGPT, suggest completions, translate, transform texts, and more. It also allows free prompting of 
ChatGPT. It uses the OpenAI chat completion API as "AI backend".

I didn't find a good location for that - how about the new subcategory CMS extensions for that?

Github: https://github.com/ist-dresden/composum-AI
Site: https://ist-dresden.github.io/composum-AI/
Quick Demo: https://www.youtube.com/watch?v=lSdKlwIDPkE / https://www.youtube.com/watch?v=96gv-F4zX_o

Language: Java
Licence: MIT licence
