### PR TITLE
Add Fellow

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,8 +387,7 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
 - [fellow](https://github.com/ManuelZierl/fellow)
 
-    Fellow is a open-source command-line AI assistant built by developers, for developers. Unlike most AI tools that stop at suggesting code, Fellow goes a step further:
-It executes tasks on your behalf. It reasons step-by-step, chooses commands from a plugin system, and edits files, generates content, or writes tests — autonomously.
+    Fellow is a open-source command-line AI assistant built by developers, for developers. Unlike most AI tools that stop at suggesting code, Fellow goes a step further: It executes tasks on your behalf. It reasons step-by-step, chooses commands from a plugin system, and edits files, generates content, or writes tests — autonomously.
 
 
 ## Chatbots


### PR DESCRIPTION
[Fellow](https://github.com/ManuelZierl/fellow) is a command-line AI assistant built by developers, for developers.

Unlike most AI tools that stop at suggesting code, Fellow goes a step further:
It executes tasks on your behalf. It reasons step-by-step, chooses commands from a plugin system, and edits files, generates content, or writes tests — autonomously.

Documentation can be found [here](https://manuelzierl.github.io/fellow/)