### PR TITLE
Add Autohand Code CLI to CLI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
     aider is a command-line chat tool that allows you to code with GPT-4 in the terminal. Ask GPT for features, improvements, or bug fixes and aider will apply the suggested changes to your source files. Each change is automatically committed to git with a descriptive commit message.
 
+- [Autohand Code CLI](https://github.com/autohandai/code-cli)
+
+    A self-evolving autonomous coding agent for the terminal that supports multiple LLM API providers including OpenRouter, Anthropic, OpenAI, and Ollama. It uses a ReAct reasoning pattern, ships with 40+ built-in tools, and integrates with VS Code and Zed editors.
+
 - [mods](https://github.com/charmbracelet/mods)
 
     mods works by reading standard in and prefacing it with a prompt supplied in the mods arguments. Optionally it formats output as Markdown, which you can pipe to markdown rendering CLIs. Example: `mods -f "what are your thoughts on improving this code?" < main.go | glow`


### PR DESCRIPTION
Autohand Code CLI is an autonomous coding agent that works across multiple LLM API providers, which makes it a natural fit for this list. Unlike most tools here that are tied to a single provider, it lets developers use their own API keys with OpenRouter, Anthropic, OpenAI, or even local models via Ollama — all through a single CLI interface.

Key points:
- Bring-your-own-key approach across 4+ LLM providers
- ReAct-based autonomous reasoning for multi-step coding tasks
- 40+ built-in tools including file editing, search, and terminal execution
- VS Code and Zed integration
- Apache 2.0 open source

Added it to the CLI section between aider and mods. Let me know if the description needs adjusting.