### PR TITLE
Add OpenClaw Easy Desktop to Desktop & Mobile Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
     A feature-rich Android ChatGPT client with Material Design 3, supporting GPT-4 Vision, DALL·E image generation, assistant mode, and a community prompts store. Allows users to configure their own API key.
 
+- [OpenClaw Easy Desktop](https://github.com/openclaw-easy/openclaw-easy-desktop)
+
+    Open-source cross-platform desktop app for setting up AI assistants on WhatsApp, Telegram, Discord, Slack and more. Bring your own API key (OpenAI, Anthropic, Google) or use local models via Ollama. Available for macOS, Windows, and Linux.
+
 ### Special-purpose
 
 - [ChatGPT Translator](https://github.com/simpleapples/chatgpt-translator)


### PR DESCRIPTION
Hi! I would like to add **OpenClaw Easy Desktop** to the Desktop & Mobile Apps > ChatGPT-like UI section.

**OpenClaw Easy Desktop** meets the collection standard:
1. It uses the ChatGPT API (`/chat/completions` endpoint) via OpenAI, Anthropic, and Google APIs.
2. Users configure their own API keys (BYOK) or use local models via Ollama.
3. It stands out from existing entries by supporting multi-channel messaging (WhatsApp, Telegram, Discord, Slack) from a single desktop app, rather than being a chat UI only.

- Website: https://openclaw-easy.com
- Source code: https://github.com/openclaw-easy/openclaw-easy-desktop
- License: MIT

Thank you for maintaining this awesome list!