### PR TITLE
Add onWatch to CLI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
     Fellow is an open-source command-line AI assistant built by developers, for developers. Unlike most AI tools that stop at suggesting code, Fellow goes a step further: It executes tasks on your behalf. It reasons step-by-step, chooses commands from a plugin system, and edits files, generates content, or writes tests — autonomously.
 
+- [onWatch](https://github.com/onllm-dev/onwatch)
+
+    Open-source Go CLI that tracks AI API quota usage across 6 providers (OpenAI, Anthropic, GitHub Copilot, and more). Runs as a background daemon with <50MB RAM, stores data locally in SQLite with zero telemetry, and includes a Material Design 3 web dashboard. Supports configuring your own API keys for each provider.
+
 ## Chatbots
 
 - Telegram

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
 - [onWatch](https://github.com/onllm-dev/onwatch)
 
-    Open-source Go CLI that tracks AI API quota usage across 6 providers (OpenAI, Anthropic, GitHub Copilot, and more). Runs as a background daemon with <50MB RAM, stores data locally in SQLite with zero telemetry, and includes a Material Design 3 web dashboard. Supports configuring your own API keys for each provider.
+    Open-source Go CLI that tracks AI API quota usage across 6 providers: OpenAI, Anthropic, GitHub Copilot, Synthetic, Z.ai, and Antigravity. Runs as a background daemon with <50MB RAM, stores data locally in SQLite with zero telemetry, and includes a Material Design 3 web dashboard. Supports configuring your own API keys for each provider.
 
 ## Chatbots
 


### PR DESCRIPTION
## What is onWatch?

[onWatch](https://github.com/onllm-dev/onwatch) is an open-source Go CLI that tracks AI API quota usage across 6 providers (OpenAI, Anthropic, GitHub Copilot, Synthetic, Z.ai, Antigravity).

It runs as a lightweight background daemon (<50MB RAM), stores everything locally in SQLite with zero telemetry, and includes a Material Design 3 web dashboard for visualization.

## Collection Standard Compliance

1. **Uses ChatGPT API**: Yes — onWatch connects to the OpenAI `/chat/completions`-compatible endpoints to monitor quota and usage.
2. **Custom API Key**: Yes — users configure their own API keys for each provider.
3. **Unique features**: No existing entry in this list covers multi-provider AI API quota tracking. onWatch is the only lightweight, local-first tool that monitors usage across 6 providers simultaneously.