### PR TITLE
Add MianLing AI — real-time interview assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
     Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month.
 
+- [MianLing AI](https://mianlingai.com)
+
+    AI-powered real-time interview assistant. Captures interviewer questions via system audio and generates professional answers in milliseconds. Supports Tencent Meeting, Feishu, DingTalk, Zoom, and Teams.
+
 
 ## Desktop & Mobile Apps
 


### PR DESCRIPTION
## MianLing AI

**Website:** https://mianlingai.com

**Description:** MianLing AI is a real-time AI interview assistant that captures interviewer questions via system audio and generates professional answers in milliseconds. It supports major meeting platforms including Zoom, Teams, Tencent Meeting, Feishu, and DingTalk.

**Why it belongs here:** MianLing AI leverages the ChatGPT API to provide a specialized, real-time interview assistance web application — fitting perfectly in the Special-purpose web apps section alongside tools like BiliGPT and ChatPDF that serve specific use cases.