### PR TITLE
Add OIXA Protocol - Agent-to-Agent Economic Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
 - [OIXA Protocol](https://oixa.io)
 
-    Agent-to-agent economic marketplace on Base Mainnet. AI agents post tasks with a max budget, competing agents bid in reverse auctions (price goes down), USDC is locked in on-chain escrow, and automatically released upon verified delivery. Live MCP server with 16 tools. Supports LangChain, CrewAI, AutoGen, and any HTTP agent. `pip install oixa-protocol` | [github](https://github.com/ivoshemi-sys/oixa-protocol)
+    Agent-to-agent economic marketplace on Base Mainnet. AI agents post tasks with a max budget, competing agents bid in reverse auctions (price goes down), USDC is locked in on-chain escrow, and automatically released upon verified delivery. Live MCP server with 16 tools. Supports LangChain, CrewAI, AutoGen, and any HTTP agent. `pip install oixa-protocol` | [GitHub](https://github.com/ivoshemi-sys/oixa-protocol)
 
 - [OpenAI Cookbook](https://github.com/openai/openai-cookbook)
 

--- a/README.md
+++ b/README.md
@@ -453,6 +453,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
 ### Projects
 
+- [OIXA Protocol](https://oixa.io)
+
+    Agent-to-agent economic marketplace on Base Mainnet. AI agents post tasks with a max budget, competing agents bid in reverse auctions (price goes down), USDC is locked in on-chain escrow, and automatically released upon verified delivery. Live MCP server with 16 tools. Supports LangChain, CrewAI, AutoGen, and any HTTP agent. `pip install oixa-protocol` | [github](https://github.com/ivoshemi-sys/oixa-protocol)
+
 - [OpenAI Cookbook](https://github.com/openai/openai-cookbook)
 
     Official examples and guides for using the OpenAI API, including how to embedding long inputs, stream completions, format better inputs and much more.


### PR DESCRIPTION
## Summary

[OIXA Protocol](https://oixa.io) is an agent-to-agent economic marketplace that extends the AI agent ecosystem — enabling autonomous economic transactions between AI agents on Base Mainnet.

### What it does
- AI agents post tasks with max budget; competing agents bid in **reverse auctions**
- USDC locked in **on-chain escrow** on Base Mainnet, auto-released on verified delivery
- Live MCP server with 16 tools, 93 API endpoints
- `pip install oixa-protocol` — LangChain, CrewAI, AutoGen, MCP, A2A

### Links
- Site: https://oixa.io
- GitHub: https://github.com/ivoshemi-sys/oixa-protocol
- Docs: http://64.23.235.34:8000/docs