### PR TITLE
Add Ajusta — AI Resume Optimizer

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -59,6 +59,10 @@
         一个Chrome扩展，总结任何网站与ChatGPT。
         其他功能包括总结任何Youtube视频的成绩单和自定义模板。这个扩展还支持ChatGPT Webapp的API，不需要配置。
 
+    - [Ajusta](https://ajusta.ai)
+
+        AI简历优化工具，可根据ATS对简历进行评分，识别关键词差距，并使用ChatGPT API提供重写建议。适用于LinkedIn和Indeed的Chrome扩展程序。
+
 - [Emacs](https://www.gnu.org/software/emacs/) Packages
 
     - [GPTel](https://github.com/karthink/gptel)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
         A Chrome extension that summarizes any website with ChatGPT.
         Other features including summarizes the transcript of any Youtube Video and customizes template. This extension also supports ChatGPT Webapp's API which requires no configuration.
 
+    - [Ajusta](https://ajusta.ai)
+
+        AI resume optimizer that scores resumes against ATS, identifies keyword gaps, and provides rewrite suggestions using ChatGPT API. Available as a Chrome extension for LinkedIn and Indeed.
+
 - [Emacs](https://www.gnu.org/software/emacs/) Packages
 
     - [GPTel](https://github.com/karthink/gptel)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
     - [Ajusta](https://ajusta.ai)
 
-        AI resume optimizer that scores resumes against ATS, identifies keyword gaps, and provides rewrite suggestions using ChatGPT API. Available as a Chrome extension for LinkedIn and Indeed.
+        AI resume optimizer that scores resumes against ATS, identifies keyword gaps, and provides rewrite suggestions using the ChatGPT API. Available as a Chrome extension for LinkedIn and Indeed job listings.
 
 - [Emacs](https://www.gnu.org/software/emacs/) Packages
 


### PR DESCRIPTION
## What is Ajusta?

[Ajusta](https://ajusta.ai) is an AI resume optimizer that uses the ChatGPT API to help job seekers improve their resumes. It scores resumes against Applicant Tracking Systems (ATS), identifies keyword gaps, and provides rewrite suggestions.

Available as a Chrome extension that works directly on LinkedIn and Indeed job listings.

## Changes

- Added Ajusta to the **Chrome Extensions** section under Plugins and Extensions

## Why it fits this list

- Users configure their own OpenAI API key
- Uses ChatGPT API for resume analysis and optimization
- Available as a Chrome extension