### PR TITLE
Add Onepilot to Desktop & Mobile Apps

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -278,6 +278,10 @@
 
     这是一个Android应用程序，通过调度和自动发送SMS文本消息(以及电话和电子邮件)来帮助您保持联系，同时利用ChatGPT生成消息。
 
+- [Onepilot](https://onepilotapp.com)
+
+    一个iOS应用程序，通过SSH连接到远程服务器，可在手机上运行Claude Code、Codex等CLI编程工具。支持OpenAI和Anthropic API，内置终端模拟器。
+
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
     An Android application that helps you stay in touch by scheduling and automating SMS text messages (and calls and email) while leveraging ChatGPT for message generation.
 
+- [Onepilot](https://onepilotapp.com)
+
+    An iOS app that lets you SSH into remote servers to run Claude Code, Codex, and other CLI coding tools from your phone. Works with OpenAI and Anthropic APIs and includes a built-in terminal emulator.
+
 - [RewriteBar](https://rewritebar.com/)
 
     A MacOS app that allows you to rewrite text using the ChatGPT API. Select text in any app and choose one of the options in the RewriteBar to rewrite the selected text. You can create your own presets for specific workflows.


### PR DESCRIPTION
Adds Onepilot to the Desktop & Mobile Apps > Special-purpose section, in both the English and Chinese READMEs.

Onepilot is an iOS app that SSHes into remote servers so you can run Claude Code, Codex, and other CLI coding tools from your phone. Works with OpenAI and Anthropic APIs and includes a built-in terminal emulator.

Website: https://onepilotapp.com