### PR TITLE
Add dassi — AI browser agent with BYOK

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
         A Chrome extension that summarizes any website with ChatGPT.
         Other features including summarizes the transcript of any Youtube Video and customizes template. This extension also supports ChatGPT Webapp's API which requires no configuration.
 
+    - [dassi](https://dassi.ai)
+
+        AI browser agent that automates work directly in Chrome — clicks, fills forms, and navigates pages on your behalf. Bring your own API key for Claude, GPT, or Gemini.
+
 - [Emacs](https://www.gnu.org/software/emacs/) Packages
 
     - [GPTel](https://github.com/karthink/gptel)


### PR DESCRIPTION
## What is dassi?

[dassi](https://dassi.ai) is an AI browser agent Chrome extension that automates work directly in your browser — it clicks, fills forms, and navigates pages on your behalf.

- **Chrome Web Store**: https://chromewebstore.google.com/detail/dassi-ai-browser-agent/bjcngahpcjeililljmfegmlanlpgibdi
- **Docs**: https://docs.dassi.ai

## Why it belongs on this list

dassi is built around the BYOK (Bring Your Own Key) model — users configure their own API keys for Claude, GPT, or Gemini. It calls the OpenAI `/chat/completions` endpoint (and equivalent endpoints for other providers) directly with the user's key.

This matches the [Collection Standard](https://github.com/reorx/awesome-chatgpt-api/issues/21):

1. **Uses the ChatGPT API** — calls `/chat/completions` with the user's configured model
2. **Custom API key** — BYOK is the core design; users bring their own OpenAI, Anthropic, or Google API key
3. **Unique features** — unlike other ChatGPT Chrome extensions on the list that focus on translation, summarization, or chat UIs, dassi is a full browser agent that autonomously performs actions (clicking, form-filling, page navigation) in the browser

## Placement

Added under **Plugins and Extensions → Chrome Extensions**, following the existing format.