### PR TITLE
Add Not Human Search and AI Dev Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,14 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
     An OpenAI API reverse proxy that can be deployed on Cloudflare Workers and Vercel Edge.
     Helpful for bypassing network restrictions or IP rate limits.
 
+- [Not Human Search](https://nothumansearch.ai)
+
+    Search engine for AI agent tools. Provides a REST API and MCP server for discovering 1,750+ agentic-ready services, enabling LLM-powered apps to find and integrate external tools programmatically.
+
+- [AI Dev Jobs](https://aidevboard.com)
+
+    AI/ML job board with REST API and MCP server. 5,500+ curated roles searchable by tag, salary, and location, designed for integration into AI-powered career tools and chatbots.
+
 
 ### Articles
 


### PR DESCRIPTION
## Summary

Adds two developer tools to the **Development > Tools** section:

- **[Not Human Search](https://nothumansearch.ai)** — Search engine for AI agent tools. REST API and MCP server for discovering 1,750+ agentic-ready services, enabling LLM-powered apps to find and integrate external tools programmatically.
- **[AI Dev Jobs](https://aidevboard.com)** — AI/ML job board with REST API and MCP server. 5,500+ curated roles searchable by tag, salary, and location, designed for integration into AI-powered career tools and chatbots.

Both provide open REST APIs and MCP (Model Context Protocol) servers that ChatGPT-powered applications can use to extend their capabilities — tool discovery and job data retrieval respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)