### PR TITLE
Add @promptunit/sdk — drop-in OpenAI client with automatic model routing

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -454,6 +454,10 @@
     OpenAI API反向代理，可以部署在Cloudflare Workers和Vercel Edge上。有助于绕过网络限制或IP速率限制。.
 
 
+- [@promptunit/sdk](https://github.com/promptunit/sdk)
+
+    一个适用于 Node.js/TypeScript 的无缝替换 OpenAI 客户端，通过 PromptUnit 的路由引擎代理调用，自动选择更便宜的模型并内置故障转移机制。在无需更改代码的情况下可降低 40-70% 的成本。
+
 ### 文章
 
 - [I got early access to ChatGPT API and then pushed it to it’s limits. Here’s what you need to know. — Buildt](https://www.buildt.ai/blog/vm3qozd4qfrbbyzukqhynrwm9vb9tq)

--- a/README.md
+++ b/README.md
@@ -505,6 +505,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
     An OpenAI API reverse proxy that can be deployed on Cloudflare Workers and Vercel Edge.
     Helpful for bypassing network restrictions or IP rate limits.
 
+- [@promptunit/sdk](https://github.com/promptunit/sdk)
+
+    A drop-in OpenAI client for Node.js/TypeScript that proxies calls through PromptUnit's routing engine, automatically selecting cheaper models with built-in failover. 40-70% cost reduction with zero code changes in your application.
+
 
 ### Articles
 


### PR DESCRIPTION
Add [@promptunit/sdk](https://github.com/promptunit/sdk) to Development > Tools.

A drop-in OpenAI client for Node.js/TypeScript that proxies calls through a routing engine, automatically selecting cheaper models (GPT-4o-mini, Claude Haiku, Gemini Flash) based on task complexity. Built-in fallback to OpenAI if the proxy is unreachable. 40-70% cost reduction, zero code changes required.

- npm: `npm install @promptunit/sdk`
- License: MIT
- Works with any existing OpenAI API call