### PR TITLE
Add AI Models Catalog — structured YAML catalog of 4,587+ AI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
     ChatGPT Wrapper is an open-source unofficial Power CLI, Python API and Flask API that lets you interact programmatically with ChatGPT/GPT4. Several different backends are supported to connect to the ChatGPT models, including browser-based and REST-based options.
 
-- [OpenAI GPT-3.5 Price Calculator](https://openai.deepakness.com/)
+- [AI Models Catalog](https://github.com/i-need-token/ai-models) — Structured YAML catalog of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. Includes an interactive catalog with price calculator, model picker, and side-by-side comparison. Available as JSON, CSV, npm package, and GitHub Action.
 
     Calculate how much it will cost to generate certain number of words by using OpenAI GPT-3.5 API.
 


### PR DESCRIPTION
## AI Models Catalog

A structured, open-source database of **4,587+ AI models** across **95 providers** with pricing, context windows, modalities, and capabilities.

### Why it's useful for ChatGPT API users
- **Model comparison**: Compare pricing and capabilities across 95 providers offering OpenAI-compatible APIs
- **OpenAI alternatives**: Dedicated page at https://i-need-token.github.io/ai-models/openai-alternatives.html
- **Free models**: 81 models at zero cost for prototyping
- **Interactive catalog**: https://i-need-token.github.io/ai-models/
- **First-party data**: All data sourced from provider APIs
- **npm package + GitHub Action**: Programmatic access

### Links
- GitHub: https://github.com/i-need-token/ai-models
- Interactive Catalog: https://i-need-token.github.io/ai-models/
- OpenAI Alternatives: https://i-need-token.github.io/ai-models/openai-alternatives.html
- Free AI Models: https://i-need-token.github.io/ai-models/free-ai-models.html