### PR TITLE
Add AI Models Catalog to Tools section

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -445,9 +445,9 @@
 
     ChatGPT Wrapper是一个开源的非官方的Power CLI, Python API和Flask API，允许您以编程方式与ChatGPT/GPT4进行交互。支持几种不同的后端连接到ChatGPT模型，包括基于浏览器和基于rest的选项。
 
-- [OpenAI GPT-3.5 Price Calculator](https://openai.deepakness.com/)
+- [AI Models Catalog](https://github.com/i-need-token/ai-models)
 
-    计算使用OpenAI GPT-3.5 API生成一定数量的单词需要花费多少。
+    结构化的AI模型YAML目录，涵盖各供应商的定价、上下文窗口和能力信息。包含交互式目录、价格计算器、模型选择器和对比功能。提供JSON、CSV、npm包和GitHub Action等多种格式。
 
 - [OpenAI proxy](https://github.com/egoist/openai-proxy)
 

--- a/README.md
+++ b/README.md
@@ -496,9 +496,9 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
     ChatGPT Wrapper is an open-source unofficial Power CLI, Python API and Flask API that lets you interact programmatically with ChatGPT/GPT4. Several different backends are supported to connect to the ChatGPT models, including browser-based and REST-based options.
 
-- [OpenAI GPT-3.5 Price Calculator](https://openai.deepakness.com/)
+- [AI Models Catalog](https://github.com/i-need-token/ai-models)
 
-    Calculate how much it will cost to generate certain number of words by using OpenAI GPT-3.5 API.
+    Structured YAML catalog of AI models across providers with pricing, context windows, and capabilities. Includes an interactive catalog with price calculator, model picker, and side-by-side comparison. Available as JSON, CSV, npm package, and GitHub Action.
 
 - [OpenAI proxy](https://github.com/egoist/openai-proxy)
 


### PR DESCRIPTION
Replaces the defunct OpenAI GPT-3.5 Price Calculator with [AI Models Catalog](https://github.com/i-need-token/ai-models) — a structured YAML catalog of AI models across providers with pricing, context windows, and capabilities.

Changes:
- Follows the repo's indented description format
- Removes specific model/provider counts for maintainability
- Updates both English and Chinese (README.cn.md) docs

The old link (openai.deepakness.com) appears to be no longer active.