### PR TITLE
Add A3M Router to Development Tools section

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -454,6 +454,11 @@
     OpenAI API反向代理，可以部署在Cloudflare Workers和Vercel Edge上。有助于绕过网络限制或IP速率限制。.
 
 
+
+- [A3M Router](https://github.com/Das-rebel/a3m-router)
+
+    A3M Router 是一个开源的LLM路由器，支持47+个提供商的并行多LLM执行。与传统的顺序fallback不同，A3M使用置信度投票机制同时运行多个提供商的模型，实现62%的成本节省和99.5%的路由准确率。仅19.5KB的CLI，零机器学习依赖。
+
 ### 文章
 
 - [I got early access to ChatGPT API and then pushed it to it’s limits. Here’s what you need to know. — Buildt](https://www.buildt.ai/blog/vm3qozd4qfrbbyzukqhynrwm9vb9tq)

--- a/README.md
+++ b/README.md
@@ -476,6 +476,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
 ### Tools
 
+- [A3M Router](https://github.com/Das-rebel/a3m-router)
+
+    Open-source LLM router with parallel multi-LLM execution across 47+ providers. Confidence-scored routing, not sequential fallback. 62% cost savings with 99.5% routing accuracy. 19.5 KB CLI, zero ML dependencies. `npm install -g adaptive-memory-multi-model-router`
+
 - [LlamaIndex 🦙 \(GPT Index\)](https://github.com/jerryjliu/gpt_index)
 
     LlamaIndex (GPT Index) is a project that provides a central interface to connect your LLM's with external data. It has a set of data structures that allow you to index your data for various LLM tasks, and remove concerns over prompt size limitations.


### PR DESCRIPTION
## Add A3M Router

**Project:** [A3M Router](https://github.com/Das-rebel/a3m-router) - Open-source LLM router with parallel multi-LLM execution across 47+ providers including OpenAI ChatGPT API.

**Why it fits:** Development tool for ChatGPT API users who need to route queries across multiple LLM providers. Features parallel execution (not sequential fallback), confidence-scored routing, and cost optimization. Works as a CLI tool installable via npm.

**npm:** `npm install -g adaptive-memory-multi-model-router`
**Benchmark:** 62% cost savings, 99.5% routing accuracy

---

> 🏆 **RouterArena #1** — 🏆 RouterArena #1: A3M scored 76.43 on the official LLM router benchmark — beating Microsoft Azure (71.87), OpenAI GPT-5 (64.32), and RouteLLM (48.07). Results: https://github.com/RouteWorks/RouterArena/pull/113
