### PR TITLE
Add ModelPriceWatch (live LLM API pricing) to Tools

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -425,6 +425,10 @@
 
 ### 工具
 
+- [ModelPriceWatch](https://modelpricewatch.com/)
+
+    实时追踪 24 家提供商、150+ 个 LLM API 的价格，并排显示输入/输出每百万 tokens 的费用，并自动从各家定价页更新，因此不会过时。当你使用自己的 API key 时，方便挑选性价比最高的模型。
+
 - [LlamaIndex 🦙 \(GPT Index\)](https://github.com/jerryjliu/gpt_index)
 
     LlamaIndex (GPT Index)是一个项目，它提供了一个中央接口来连接您的LLM与外部数据。它有一组数据结构，允许您为各种LLM任务索引数据，并消除对提示大小限制的担忧。

--- a/README.md
+++ b/README.md
@@ -476,6 +476,9 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
 ### Tools
 
+- [ModelPriceWatch](https://modelpricewatch.com/?utm_source=awesome-chatgpt-api&utm_medium=readme&utm_campaign=reorx-chatgpt-api)
+
+    Live pricing tracker for 150+ LLM APIs across 24 providers, showing input/output $/Mtok side by side and auto-updating from provider pricing pages. Handy for picking the cheapest model when you run on your own API key.
 - [LlamaIndex 🦙 \(GPT Index\)](https://github.com/jerryjliu/gpt_index)
 
     LlamaIndex (GPT Index) is a project that provides a central interface to connect your LLM's with external data. It has a set of data structures that allow you to index your data for various LLM tasks, and remove concerns over prompt size limitations.

--- a/README.md
+++ b/README.md
@@ -476,9 +476,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
 
 ### Tools
 
-- [ModelPriceWatch](https://modelpricewatch.com/?utm_source=awesome-chatgpt-api&utm_medium=readme&utm_campaign=reorx-chatgpt-api)
+- [ModelPriceWatch](https://modelpricewatch.com/)
 
     Live pricing tracker for 150+ LLM APIs across 24 providers, showing input/output $/Mtok side by side and auto-updating from provider pricing pages. Handy for picking the cheapest model when you run on your own API key.
+
 - [LlamaIndex 🦙 \(GPT Index\)](https://github.com/jerryjliu/gpt_index)
 
     LlamaIndex (GPT Index) is a project that provides a central interface to connect your LLM's with external data. It has a set of data structures that allow you to index your data for various LLM tasks, and remove concerns over prompt size limitations.


### PR DESCRIPTION
Hi — thanks for maintaining awesome-chatgpt-api.

**Disclosure:** I maintain ModelPriceWatch, so this adds a project I'm affiliated with — flagging up front per self-promotion norms. Happy to decline, move, or reword.

Since the tools here run on the reader's own API key, cost is a direct concern — the **Tools** section already lists the GPT price calculator and Tiktokenizer. [ModelPriceWatch](https://modelpricewatch.com) tracks live input/output $/Mtok across 150+ LLM APIs and 24 providers and auto-updates from provider pricing pages, so it's an easy way to pick the cheapest model for a given job.

Added one entry under **Tools**, matching the list's link + description format. Totally fine if it's not a fit.
