### PR TITLE
docs: add AI Router to development tools

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -453,6 +453,10 @@
 
     OpenAI API反向代理，可以部署在Cloudflare Workers和Vercel Edge上。有助于绕过网络限制或IP速率限制。.
 
+- [AI Router](https://ai-router.dev/)
+
+    面向开发者的 OpenAI-compatible ChatGPT API 中转服务。用户可创建自己的 API Key，通过将 Base URL 切换到 `https://api.ai-router.dev/v1` 接入现有 SDK 和工具，并查看每个 Key 的用量与 Token/费用统计。
+
 
 ### 文章
 

--- a/README.cn.md
+++ b/README.cn.md
@@ -453,9 +453,9 @@
 
     OpenAI API反向代理，可以部署在Cloudflare Workers和Vercel Edge上。有助于绕过网络限制或IP速率限制。.
 
-- [AI Router](https://ai-router.dev/)
+- [AI Router](https://ai-router.dev)
 
-    面向开发者的 OpenAI-compatible ChatGPT API 中转服务。用户可创建自己的 API Key，通过将 Base URL 切换到 `https://api.ai-router.dev/v1` 接入现有 SDK 和工具，并查看每个 Key 的用量与 Token/费用统计。
+    面向开发者的 OpenAI-compatible ChatGPT API 中转服务，提供 API key 管理和按 key 用量可视化；用户可将 Base URL 切换到 `https://api.ai-router.dev/v1` 接入现有 SDK 和工具，并查看每个 Key 的用量统计。
 
 
 ### 文章

--- a/README.md
+++ b/README.md
@@ -505,6 +505,10 @@ Visit the website to get latest updates: [awesome-chatgpt-api.top](https://aweso
     An OpenAI API reverse proxy that can be deployed on Cloudflare Workers and Vercel Edge.
     Helpful for bypassing network restrictions or IP rate limits.
 
+- [AI Router](https://ai-router.dev/)
+
+    An OpenAI-compatible ChatGPT API relay for developers. Users create their own API keys, keep usage and token/cost visibility per key, and can switch existing SDKs/tools by changing the base URL to `https://api.ai-router.dev/v1`.
+
 
 ### Articles
 


### PR DESCRIPTION
Adds AI Router as an OpenAI-compatible ChatGPT API relay under the Development / Tools section.

Why it fits the collection standard:
- uses the ChatGPT-compatible `/chat/completions` flow
- users configure their own AI Router API keys
- existing SDKs/tools work by switching the base URL to `https://api.ai-router.dev/v1`

This is an operator self-submission and keeps the entry concise.